### PR TITLE
Added Gitter sidecar to Topsoil

### DIFF
--- a/_includes/gitter_sidecar.html
+++ b/_includes/gitter_sidecar.html
@@ -1,0 +1,6 @@
+<script>
+  ((window.gitter = {}).chat = {}).options = {
+    room: '{{ include.room }}'
+  };
+</script>
+<script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>

--- a/projects/topsoil/index.html
+++ b/projects/topsoil/index.html
@@ -17,3 +17,5 @@ category-order:
 {% assign items = site.topsoil %}
 
 {% include help.html %}
+
+{% include gitter_sidecar.html room="CIRDLES/Topsoil" %}


### PR DESCRIPTION
Fixes #60 by adding a Gitter sidecar to the Topsoil project page.
Upon navigating to the Topsoil project page, the user now sees an
"Open Chat" tab in the lower right corner. Clicking it opens the
Gitter sidecar, and the user can participate in the CIRDLES/Topsoil
Gitter chat room.

In the process, I added a new include, gitter_sidecar.html. It can add
the "Open Chat" tab for any room to any page as follows:

```
{% include gitter_sidecar.html room="ROOM_NAME_HERE" %}
```