### PR TITLE
Switched to Markdown links

### DIFF
--- a/_topsoil/ASimpleTutorial.md
+++ b/_topsoil/ASimpleTutorial.md
@@ -12,7 +12,7 @@ Before starting, please install Topsoil.
 
 After opening Topsoil, we first need to import some data. Copy the table below by first highlighting the text. Then, click on the Topsoil data table and paste it in by using the paste shortcut (control-v on Windows or command-v on Mac).
 
-There is a chart on Topsoil's wiki page on <a href="https://github.com/CIRDLES/topsoil/wiki#a-simple-tutorial" target="_blank">github.com</a> where you can retrieve sample values.
+There is [a chart of sample data][]{:target="_blank"} on Topsoil's GitHub wiki.
 
 <!---207Pb\*/235U | ±2&sigma; (%) | 206Pb\*/238U | ±2&sigma; (%) |  corr coef
 -------------|---------------|-------------|---------------|------------
@@ -38,3 +38,5 @@ There is a chart on Topsoil's wiki page on <a href="https://github.com/CIRDLES/t
 Now that we have data, let's make it into a new chart. To do this, first click the "Error Ellipse Chart" button on the toolbar. A dialog should now appear asking you to choose the columns that correspond to each of the variables. For this example, Topsoil's default selection is correct, so ensure that the x- and y-errors are identified as 1σ and percentages (or else choose the correct options from the drop down menus) and press "Create chart".
 
 Congratulations! You have successfully created your first chart with Topsoil!
+
+[a chart of sample data]: https://github.com/CIRDLES/topsoil/wiki#a-simple-tutorial

--- a/_topsoil/Installation.md
+++ b/_topsoil/Installation.md
@@ -6,4 +6,4 @@ title: Installation
 reference: Installation
 ---
 
-To install Topsoil, first ensure that your computer meets our system requirements and then download the latest JAR file from the <a href="https://github.com/CIRDLES/topsoil/releases">releases page</a>.
+To install Topsoil, first ensure that your computer meets our system requirements and then download the latest JAR file from the [releases page](https://github.com/CIRDLES/topsoil/releases).

--- a/_topsoil/system-requirements.md
+++ b/_topsoil/system-requirements.md
@@ -6,6 +6,6 @@ title: System Requirements
 reference: system-requirements
 ---
 
-Topsoil will run on Windows (x86 and x64), Linux (x86 and x64), and Mac (x64 only). Topsoil requires the latest version of Java (1.8 or higher), the installer for which can be found <a href="http://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html" target="_blank">here</a>.
+Topsoil will run on Windows (x86 and x64), Linux (x86 and x64), and Mac (x64 only). Topsoil requires the [latest version of Java][]{:target = "_blank"} (1.8 or higher).
 
-If you are unsure which Java version you have active on your system, we provide a tool, javacheck-0.1.0.jar, on the <a href="https://github.com/CIRDLES/topsoil/releases" target="_blank">releases page</a> to assist you. Simply download the file and double-click it. It requires a JRE (1.3 or newer) to run.
+[latest version of Java]: http://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html

--- a/_topsoil/welcome.md
+++ b/_topsoil/welcome.md
@@ -9,11 +9,11 @@ Topsoil is a desktop application and Java library that creates data visualizatio
 
 The name "Topsoil" is an anagram of "Isoplot", the name of an enormously successful Microsoft Excel Add-In with similar capabilities that now works only in older versions of Excel.
 
-If you are interested in learning more about Topsoil, please contact <a href="mailto:bowringj@cofc.edu?subject=CIRDLES">Jim Bowring</a>.
+If you are interested in learning more about Topsoil, please contact [Jim Bowring](mailto:bowringj@cofc.edu?subject=CIRDLES).
 
 To cite Topsoil, please provide a footnote or acknowledgement as follows:
 
 J.F. Bowring, PI CIRDLES.org Open Source Development Team. Topsoil - A community driven replacement for ISOPLOT. Apache License, Version 2.0.
-<a href="https://github.com/CIRDLES/topsoil" target="_blank">https://github.com/CIRDLES/topsoil</a>.
+[https://github.com/CIRDLES/topsoil](https://github.com/CIRDLES/topsoil){:target = "_blank"}
 
 We have an article in production that will become the official citable reference, stay tuned.


### PR DESCRIPTION
Switched from HTML- to Markdown-style links. Removed dated information
on Java Check(er?) tool, as that will be deprecated by the project Ben's
working on.