### PR TITLE
modifying chroni page

### DIFF
--- a/_chroni/help.md
+++ b/_chroni/help.md
@@ -25,7 +25,7 @@ F&Q:
 <em>How can I download new report settings?</em>
 
 * You can create custom report settings by using ET\_Redux
-* The <a href="https://cirdles.org/projects/et_redux" target="_blank">ET&lowbar;Redux Project</a> can tell you more about creating samples
+* The <a href="https://cirdles.org/projects/et_redux" target="_blank">ET-Redux Project</a> can tell you more about creating samples
 * Save the report settings as an xml file and send it to your email, then download the file onto your device
 * Save the file in the Chroni Report Settings folder
 


### PR DESCRIPTION
there was an html entity "&lowbar" that was not showing up properly, but the intended character "-" does display as is on the browser so I just typed in the character.