### PR TITLE
Uses logo from DRAKE via url

### DIFF
--- a/_squid/repositorySquid.md
+++ b/_squid/repositorySquid.md
@@ -8,7 +8,7 @@ reference: repository
 
 
 <a href="https://github.com/CIRDLES/Squid" target="_blank">
-<img src="/assets/icons/SquidLogo.png" alt="link to Squid repository" height="80" width="80">
+<img src="https://raw.githubusercontent.com/CIRDLES/DRAKE/master/logos/Squid/SquidLogo.png" alt="link to Squid repository" height="80" width="80">
 </a>
 
 [*If you have ideas about how to improve the help, report them here!*](https://github.com/CIRDLES/Squid/issues/new)


### PR DESCRIPTION
Serves as example for using our logos from DRAKE instead of using copies in assets.  @Jmack2  and 
@maniacimm  please look at doing this for all logos and cleaning out assets of duplicates.